### PR TITLE
user can now delete tags. still need some css

### DIFF
--- a/TabloidMVC/Controllers/TagController.cs
+++ b/TabloidMVC/Controllers/TagController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.VisualBasic;
@@ -37,6 +38,27 @@ namespace TabloidMVC.Controllers
             try
             {
                 _tagRepository.AddTag(tag);
+
+                return RedirectToAction("Index");
+            }
+            catch (Exception ex)
+            {
+                return View(tag);
+            }
+        }
+
+        public ActionResult DeleteTag(int id)
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult DeleteTag(int id, Tag tag)
+        {
+            try
+            {
+                _tagRepository.DeleteTag(id);
 
                 return RedirectToAction("Index");
             }

--- a/TabloidMVC/Repositories/ITagRepository.cs
+++ b/TabloidMVC/Repositories/ITagRepository.cs
@@ -7,5 +7,6 @@ namespace TabloidMVC.Repositories
     {
         List<Tag> GetAll();
         void AddTag(Tag tag);
+        void DeleteTag(int id);
     }
 }

--- a/TabloidMVC/Repositories/TagRepository.cs
+++ b/TabloidMVC/Repositories/TagRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using TabloidMVC.Models;
 
@@ -51,6 +52,26 @@ namespace TabloidMVC.Repositories
                     cmd.Parameters.AddWithValue("@Name", tag.Name);
 
                     tag.Id = (int)cmd.ExecuteScalar();
+                }
+            }
+        }
+
+        public void DeleteTag(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        DELETE FROM Tag
+                        WHERE Id = @id
+                    ";
+
+                    cmd.Parameters.AddWithValue("@id", id);
+
+                    cmd.ExecuteNonQuery();
                 }
             }
         }

--- a/TabloidMVC/Views/Tag/Create.cshtml
+++ b/TabloidMVC/Views/Tag/Create.cshtml
@@ -4,10 +4,6 @@
     ViewData["Title"] = "Create";
 }
 
-<h1>Create</h1>
-
-<h4>Tag</h4>
-<hr />
 <div class="container pt-5">
     <div class="row justify-content-center">
         <div class="card col-md-12 col-lg-8">

--- a/TabloidMVC/Views/Tag/DeleteTag.cshtml
+++ b/TabloidMVC/Views/Tag/DeleteTag.cshtml
@@ -1,0 +1,32 @@
+﻿@model TabloidMVC.Models.Tag
+
+@{
+    ViewData["Title"] = "DeleteTag";
+}
+
+<h1>DeleteTag</h1>
+
+<h3>Are you sure you want to delete this tag?</h3>
+<div>
+    <h4>Tag</h4>
+    <hr />
+    <dl class="row">
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Id)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Id)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Name)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Name)
+        </dd>
+    </dl>
+    
+    <form asp-action="DeleteTag">
+        <input type="submit" value="Delete" class="btn btn-danger" /> |
+        <a asp-action="Index">Back to List</a>
+    </form>
+</div>

--- a/TabloidMVC/Views/Tag/Index.cshtml
+++ b/TabloidMVC/Views/Tag/Index.cshtml
@@ -34,7 +34,7 @@
                         <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
                             <i class="fas fa-pencil-alt"></i>
                         </a>
-                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                        <a asp-action="DeleteTag" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
                             <i class="fas fa-trash"></i>
                         </a>
                     </td>


### PR DESCRIPTION
# Description
User can now delete a tag from the list. Tag is also removed from the database.
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)
# Testing Instructions
Log in to tabloid and navigate to tag management. Select the trashcan icon of the tag you would like to delete. You will be asked if you are sure, select the delete button to confirm the action.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works